### PR TITLE
Make zsh find the correct gem binary

### DIFF
--- a/etc/rbenv.d/install/default-gems.bash
+++ b/etc/rbenv.d/install/default-gems.bash
@@ -34,9 +34,12 @@ install_default_gems() {
       # Invoke `gem install` in the just-installed Ruby. Point its
       # stdin to /dev/null or else it'll read from our default-gems
       # file.
-      RBENV_VERSION="$VERSION_NAME" gem install "$gem_name" "${args[@]}" < /dev/null || {
-        echo "rbenv: error installing gem \`$gem_name'"
-      } >&2
+      (
+        export RBENV_VERSION="$VERSION_NAME"
+        "$(rbenv-which gem)" install "$gem_name" "${args[@]}" < /dev/null || {
+            echo "rbenv: error installing gem \`$gem_name'"
+        } >&2
+      )
 
     done < "${RBENV_ROOT}/default-gems"
   fi


### PR DESCRIPTION
`rbenv-default-gems` finds the system gem instead of the one in the newly built ruby (first ruby built after installing rbenv from scratch). I'm guessing it wants a call to `rehash` or something to that effect before invoking it.
