### PR TITLE
Allow operating system specific gems

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,15 @@ rbenv-default-gems automatically installs the gems listed in the
 version of Ruby with `rbenv install`.
 
 Specify gems in `~/.rbenv/default-gems` by name, one per line. You may
-optionally specify a version string after the name, or `--pre` to
-install a prerelease version. For example:
+optionally specify a version string after the name, `--pre` to
+install a prerelease version, or a specific operating system to install the gem on. For example:
 
     bundler
     bcat ~>0.6
     rails --pre
+    rb-fsevent osx
+    rb-inotify linux
+    rb-notifu windows
 
 Blank lines and lines beginning with a `#` are ignored.
 

--- a/etc/rbenv.d/install/default-gems.bash
+++ b/etc/rbenv.d/install/default-gems.bash
@@ -4,12 +4,23 @@ else
   echo "rbenv: rbenv-default-gems plugin requires ruby-build 20130129 or later" >&2
 fi
 
+os_version() {
+  case "$OSTYPE" in
+    darwin*) echo "osx" ;;
+    mswin*|mingw*) echo "windows" ;;
+    *) echo "linux" ;;
+  esac
+}
+
 install_default_gems() {
   # Only install default gems after successfully installing Ruby.
   [ "$STATUS" = "0" ] || return 0
 
   if [ -f "${RBENV_ROOT}/default-gems" ]; then
-    local line gem_name gem_version args
+    local line gem_name gem_version args current_os
+
+    # Get the current base OS
+    current_os=$(os_version)
 
     # Read gem names and versions from $RBENV_ROOT/default-gems.
     while IFS=" " read -r -a line; do
@@ -25,6 +36,10 @@ install_default_gems() {
 
       if [ "$gem_version" == "--pre" ]; then
         args=( --pre )
+      elif [[ "$gem_version" =~ [osx|linux|windows] ]]; then
+        if [ "$current_os" != "$gem_version" ]; then
+          continue
+        fi
       elif [ -n "$gem_version" ]; then
         args=( --version "$gem_version" )
       else


### PR DESCRIPTION
A small patch to allow you to add a specific operating system argument to your `default-gems` file so the gem will only be installed on that OS.
