### PR TITLE
Arguments fix for --no-doc's

### DIFF
--- a/etc/rbenv.d/install/default-gems.bash
+++ b/etc/rbenv.d/install/default-gems.bash
@@ -24,9 +24,15 @@ install_default_gems() {
       gem_version="${line[1]}"
       gem_no_document="${line[2]}"
       gem_install="install"
-      
+
+      if [[ "$VERSION_NAME" =~ "1.9.3" ]] ; then
+        nodocs="--no-ri --no-rdoc"
+      else
+        nodocs="--no-document"
+      fi
+
       arguments=""
-      if [ "$gem_name" == "specific_install" ]; then
+      if [ "$gem_name" == "specific_install" -a "$gem_version" != "--no-document" ]; then
         gem_install="specific_install"
         gem_name=""
         arguments="$gem_version"
@@ -34,13 +40,13 @@ install_default_gems() {
         if [ "$gem_version" == "--pre" ]; then
           arguments=" --pre "
         elif [ "$gem_version" == "--no-document" ]; then
-          arguments=" --no-document "
+          arguments=" $nodocs "
         elif [ -n "$gem_version" ]; then
           arguments=" --version '$gem_version' "
         fi
       
         if [ "$gem_no_document" == "--no-document" ]; then
-          arguments="$arguments --no-document "
+          arguments="$arguments $nodocs "
         fi
       fi
       

--- a/etc/rbenv.d/install/default-gems.bash
+++ b/etc/rbenv.d/install/default-gems.bash
@@ -22,14 +22,22 @@ install_default_gems() {
 
       gem_name="${line[0]}"
       gem_version="${line[1]}"
-
+      gem_no_document="${line[2]}"
+      arguments=""
+      
       if [ "$gem_version" == "--pre" ]; then
-        args=( --pre )
+        arguments=" --pre "
+      elif [ "$gem_version" == "--no-document" ]; then
+        arguments=" --no-document "
       elif [ -n "$gem_version" ]; then
-        args=( --version "$gem_version" )
-      else
-        args=()
+        arguments=" --version '$gem_version' "
       fi
+      
+      if [ "$gem_no_document" == "--no-document" ]; then
+        arguments="$arguments --no-document "
+      fi
+      
+      args=( ${arguments} )
 
       # Invoke `gem install` in the just-installed Ruby. Point its
       # stdin to /dev/null or else it'll read from our default-gems

--- a/etc/rbenv.d/install/default-gems.bash
+++ b/etc/rbenv.d/install/default-gems.bash
@@ -23,18 +23,22 @@ install_default_gems() {
       gem_name="${line[0]}"
       gem_version="${line[1]}"
       gem_no_document="${line[2]}"
+      
       arguments=""
+      if [ "$gem_name" == "specific_install" && -n "$gem_version" ]; then
+        arguments="specific_install $gem_version"
+      else
+        if [ "$gem_version" == "--pre" ]; then
+          arguments=" --pre "
+        elif [ "$gem_version" == "--no-document" ]; then
+          arguments=" --no-document "
+        elif [ -n "$gem_version" ]; then
+          arguments=" --version '$gem_version' "
+        fi
       
-      if [ "$gem_version" == "--pre" ]; then
-        arguments=" --pre "
-      elif [ "$gem_version" == "--no-document" ]; then
-        arguments=" --no-document "
-      elif [ -n "$gem_version" ]; then
-        arguments=" --version '$gem_version' "
-      fi
-      
-      if [ "$gem_no_document" == "--no-document" ]; then
-        arguments="$arguments --no-document "
+        if [ "$gem_no_document" == "--no-document" ]; then
+          arguments="$arguments --no-document "
+        fi
       fi
       
       args=( ${arguments} )

--- a/etc/rbenv.d/install/default-gems.bash
+++ b/etc/rbenv.d/install/default-gems.bash
@@ -23,10 +23,12 @@ install_default_gems() {
       gem_name="${line[0]}"
       gem_version="${line[1]}"
       gem_no_document="${line[2]}"
+      gem_install="install"
       
       arguments=""
       if [ "$gem_name" == "specific_install" ]; then
-        arguments="specific_install $gem_version"
+        gem_install="specific_install"
+        arguments="$gem_version"
       else
         if [ "$gem_version" == "--pre" ]; then
           arguments=" --pre "
@@ -46,7 +48,7 @@ install_default_gems() {
       # Invoke `gem install` in the just-installed Ruby. Point its
       # stdin to /dev/null or else it'll read from our default-gems
       # file.
-      RBENV_VERSION="$VERSION_NAME" rbenv-exec gem install "$gem_name" "${args[@]}" < /dev/null || {
+      RBENV_VERSION="$VERSION_NAME" rbenv-exec gem "$gem_install" "$gem_name" "${args[@]}" < /dev/null || {
         echo "rbenv: error installing gem \`$gem_name'"
       } >&2
 

--- a/etc/rbenv.d/install/default-gems.bash
+++ b/etc/rbenv.d/install/default-gems.bash
@@ -25,7 +25,7 @@ install_default_gems() {
       gem_no_document="${line[2]}"
       
       arguments=""
-      if [ "$gem_name" == "specific_install" && -n "$gem_version" ]; then
+      if [ "$gem_name" == "specific_install" ]; then
         arguments="specific_install $gem_version"
       else
         if [ "$gem_version" == "--pre" ]; then

--- a/etc/rbenv.d/install/default-gems.bash
+++ b/etc/rbenv.d/install/default-gems.bash
@@ -23,7 +23,7 @@ install_default_gems() {
       gem_name="${line[0]}"
       gem_version="${line[1]}"
       gem_no_document="${line[2]}"
-      gem_install="install"
+      gem_install="install $gem_name"
       
       arguments=""
       if [ "$gem_name" == "specific_install" ]; then
@@ -48,7 +48,7 @@ install_default_gems() {
       # Invoke `gem install` in the just-installed Ruby. Point its
       # stdin to /dev/null or else it'll read from our default-gems
       # file.
-      RBENV_VERSION="$VERSION_NAME" rbenv-exec gem "$gem_install" "$gem_name" "${args[@]}" < /dev/null || {
+      RBENV_VERSION="$VERSION_NAME" rbenv-exec gem "$gem_install" "${args[@]}" < /dev/null || {
         echo "rbenv: error installing gem \`$gem_name'"
       } >&2
 

--- a/etc/rbenv.d/install/default-gems.bash
+++ b/etc/rbenv.d/install/default-gems.bash
@@ -23,11 +23,12 @@ install_default_gems() {
       gem_name="${line[0]}"
       gem_version="${line[1]}"
       gem_no_document="${line[2]}"
-      gem_install="install $gem_name"
+      gem_install="install"
       
       arguments=""
       if [ "$gem_name" == "specific_install" ]; then
         gem_install="specific_install"
+        gem_name=""
         arguments="$gem_version"
       else
         if [ "$gem_version" == "--pre" ]; then
@@ -48,7 +49,7 @@ install_default_gems() {
       # Invoke `gem install` in the just-installed Ruby. Point its
       # stdin to /dev/null or else it'll read from our default-gems
       # file.
-      RBENV_VERSION="$VERSION_NAME" rbenv-exec gem "$gem_install" "${args[@]}" < /dev/null || {
+      RBENV_VERSION="$VERSION_NAME" rbenv-exec gem "$gem_install" "$gem_name" "${args[@]}" < /dev/null || {
         echo "rbenv: error installing gem \`$gem_name'"
       } >&2
 


### PR DESCRIPTION
Now we able to write:
bundler --no-document
or
bundler --pre --no-document
or
bundler --version '1.0.0' --no-document
or (for install doc's) 
bundler --pre
