### PR TITLE
Update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Ruby.
 
 Make sure you have the latest rbenv and ruby-build versions, then run:
 
-    git clone https://github.com/sstephenson/rbenv-default-gems.git $(rbenv root)/plugins/rbenv-default-gems
+    git clone https://github.com/rbenv/rbenv-default-gems.git $(rbenv root)/plugins/rbenv-default-gems
 
 ## Usage
 


### PR DESCRIPTION
@sstephenson / @mislav - Just a minor update to the installation instructions, to ensure they reference `rbenv/rbenv-default-gems` instead of `sstephenson/rbenv-default-gems`... thanks!
